### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD Pipeline
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [main, master, dev]


### PR DESCRIPTION
Potential fix for [https://github.com/NamlessChokko/discord-gemini-chatbot/security/code-scanning/2](https://github.com/NamlessChokko/discord-gemini-chatbot/security/code-scanning/2)

To fix the problem, you should add an explicit `permissions` block to the workflow file `.github/workflows/ci.yml`. This block can be added at the root level (applies to all jobs) or at the job level (applies only to the specific job). Since both jobs (`test` and `security`) only need to read the repository contents, the minimal and recommended fix is to add `permissions: contents: read` at the root of the workflow, just below the `name` and before the `on` block. This ensures that all jobs in the workflow run with the least privilege required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
